### PR TITLE
Updated resolve module to support init.lua files

### DIFF
--- a/src/bundle/process.ts
+++ b/src/bundle/process.ts
@@ -39,6 +39,12 @@ export function resolveModule(name: string, packagePaths: readonly string[]) {
 		if (existsSync(path) && lstatSync(path).isFile()) {
 			return path
 		}
+
+		const initPath = pattern.replace(/\?/g, `${platformName}/init`)
+
+		if (existsSync(initPath) && lstatSync(initPath).isFile()) {
+			return initPath
+		}
 	}
 	return null
 }


### PR DESCRIPTION
Require resolution allows for an `init.lua` file at the directory level so `require('module')` can resolve to `module/init.lua`.

This minor update allows the bundler to pull in a module based on it's `init.lua` file.